### PR TITLE
Use more specific patterns in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
 .DS_Store
 .cache
 build
-fonts
+/fonts
 tmp
-third_party/platform
+/third_party/platform
 compile_commands.json
 TODO.md
-resources
+/resources


### PR DESCRIPTION
Context: I am trying to pack a tarball of all sources needed to build ODE and a tool I use ignores stuff in .gitignore. This leads to missing source files, because `/src/fonts` matches `fonts`. I scoped few extras which seem like it might happen for in the future, but feel free to change this.